### PR TITLE
Add ChatDock overlay to Shell

### DIFF
--- a/vite-react-main/src/components/Shell.tsx
+++ b/vite-react-main/src/components/Shell.tsx
@@ -4,6 +4,7 @@ import type { Post, User } from "../types";
 import BrandBadge from "./BrandBadge";
 import PostCard from "./PostCard";
 import AssistantOrb from "./AssistantOrb";
+import ChatDock from "./ChatDock";
 import World3D from "./World3D";
 
 const IMG = (id: number) => `https://picsum.photos/id/${id}/1080/1350`;
@@ -61,6 +62,7 @@ export default function Shell() {
 
       {/* Floating orb (bottom-right) */}
       <AssistantOrb />
+      <ChatDock />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- display chat bubbles by importing and rendering `ChatDock` in `Shell`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cfa503a9c8321bc78f2de9302ab4b