### PR TITLE
feat: virtualized feed with store

### DIFF
--- a/vite-react-main/package-lock.json
+++ b/vite-react-main/package-lock.json
@@ -12,6 +12,7 @@
         "@react-three/fiber": "8.15.19",
         "@react-three/postprocessing": "2.19.1",
         "@react-three/xr": "^6.6.22",
+        "@tanstack/react-virtual": "^3.13.12",
         "framer-motion": "12.23.12",
         "hls.js": "1.6.9",
         "react": "18.3.1",
@@ -29,6 +30,9 @@
         "typescript": "5.5.4",
         "vite": "5.4.9",
         "vite-plugin-glsl": "1.5.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1457,6 +1461,33 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
+      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
     },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.3",

--- a/vite-react-main/package.json
+++ b/vite-react-main/package.json
@@ -13,26 +13,27 @@
     "preview": "vite preview --port 5173"
   },
   "dependencies": {
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "three": "0.165.0",
-    "@react-three/fiber": "8.15.19",
     "@react-three/drei": "9.100.0",
+    "@react-three/fiber": "8.15.19",
     "@react-three/postprocessing": "2.19.1",
     "@react-three/xr": "^6.6.22",
-    "zustand": "4.5.2",
+    "@tanstack/react-virtual": "^3.13.12",
     "framer-motion": "12.23.12",
+    "hls.js": "1.6.9",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
     "react-router-dom": "7.8.0",
-    "hls.js": "1.6.9"
+    "three": "0.165.0",
+    "zustand": "4.5.2"
   },
   "devDependencies": {
-    "typescript": "5.5.4",
-    "vite": "5.4.9",
-    "@vitejs/plugin-react": "4.3.2",
+    "@types/hls.js": "1.0.0",
     "@types/react": "18.3.5",
     "@types/react-dom": "18.3.0",
     "@types/three": "0.165.0",
-    "@types/hls.js": "1.0.0",
+    "@vitejs/plugin-react": "4.3.2",
+    "typescript": "5.5.4",
+    "vite": "5.4.9",
     "vite-plugin-glsl": "1.5.1"
   }
 }

--- a/vite-react-main/src/components/Shell.tsx
+++ b/vite-react-main/src/components/Shell.tsx
@@ -1,10 +1,11 @@
-import { useMemo } from "react";
+import { useMemo, useEffect } from "react";
 import "./Shell.css";
 import type { Post, User } from "../types";
 import BrandBadge from "./BrandBadge";
-import PostCard from "./PostCard";
 import AssistantOrb from "./AssistantOrb";
 import World3D from "./World3D";
+import Feed from "./Feed";
+import { useFeedStore } from "../lib/feedStore";
 
 const IMG = (id: number) => `https://picsum.photos/id/${id}/1080/1350`;
 const SEED = [
@@ -30,6 +31,11 @@ export default function Shell() {
     []
   );
 
+  const setPosts = useFeedStore((s) => s.setPosts);
+  useEffect(() => {
+    setPosts(posts);
+  }, [posts, setPosts]);
+
   const onEnterWorld = () => {
     console.log("Enter Universe");
   };
@@ -45,19 +51,11 @@ export default function Shell() {
       <BrandBadge onEnterUniverse={onEnterWorld} />
 
       {/* Feed */}
-      <main className="content-viewport feed-wrap">
-        <div className="feed-content">
-          {posts.map((p: Post) => (
-            <PostCard
-              key={p.id}
-              post={p}
-              me={me}
-              onOpenProfile={(id) => console.log("profile:", id)}
-              onEnterWorld={onEnterWorld}
-            />
-          ))}
-        </div>
-      </main>
+      <Feed
+        me={me}
+        onOpenProfile={(id) => console.log("profile:", id)}
+        onEnterWorld={onEnterWorld}
+      />
 
       {/* Floating orb (bottom-right) */}
       <AssistantOrb />

--- a/vite-react-main/src/components/feed/Feed.tsx
+++ b/vite-react-main/src/components/feed/Feed.tsx
@@ -1,21 +1,62 @@
+import { useRef, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { Post, User } from "../../types";
 import PostCard from "../PostCard";
+import { usePaginatedPosts } from "../../lib/feedStore";
 import "./Feed.css";
 
 type Props = {
-  posts: Post[];
   me: User;
   onOpenProfile?: (id: string) => void;
   onEnterWorld: () => void;
 };
 
-export default function Feed({ posts, me, onOpenProfile, onEnterWorld }: Props) {
+const PAGE_SIZE = 50;
+
+export default function Feed({ me, onOpenProfile, onEnterWorld }: Props) {
+  const [page] = useState(0);
+  const posts = usePaginatedPosts(page, PAGE_SIZE);
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  const rowVirtualizer = useVirtualizer({
+    count: posts.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 500,
+    measureElement: (el) => el.getBoundingClientRect().height,
+    overscan: 5,
+  });
+
   return (
-    <div className="content-viewport feed-wrap">
-      <div className="feed-content">
-        {posts.map((p) => (
-          <PostCard key={p.id} post={p} me={me} onOpenProfile={onOpenProfile} onEnterWorld={onEnterWorld} />
-        ))}
+    <div ref={parentRef} className="content-viewport feed-wrap">
+      <div
+        className="feed-content"
+        style={{ height: rowVirtualizer.getTotalSize(), position: "relative" }}
+      >
+        {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+          const post = posts[virtualRow.index] as Post;
+          return (
+            <div
+              key={post.id}
+              data-index={virtualRow.index}
+              ref={rowVirtualizer.measureElement}
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: "100%",
+                transform: `translateY(${virtualRow.start}px)`,
+                paddingBottom: "var(--post-gap)",
+              }}
+            >
+              <PostCard
+                post={post}
+                me={me}
+                onOpenProfile={onOpenProfile}
+                onEnterWorld={onEnterWorld}
+              />
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/vite-react-main/src/components/index.ts
+++ b/vite-react-main/src/components/index.ts
@@ -2,4 +2,5 @@ export { default as Sidebar } from "./Sidebar";
 export { default as Feed2D } from "./Feed2D";
 export { default as World3D } from "./World3D";
 export { default as AssistantOrb } from "./AssistantOrb";
+export { default as Feed } from "./Feed";
 export type { Post } from "../types";

--- a/vite-react-main/src/lib/feedStore.ts
+++ b/vite-react-main/src/lib/feedStore.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+import type { Post } from "../types";
+
+interface FeedState {
+  posts: Post[];
+  setPosts: (posts: Post[]) => void;
+}
+
+export const useFeedStore = create<FeedState>((set) => ({
+  posts: [],
+  setPosts: (posts) => set({ posts }),
+}));
+
+export function usePaginatedPosts(page: number, pageSize: number) {
+  return useFeedStore((state) => {
+    const start = page * pageSize;
+    return state.posts.slice(start, start + pageSize);
+  });
+}


### PR DESCRIPTION
## Summary
- virtualize Feed with @tanstack/react-virtual to only render visible posts
- add zustand feed store and paginated selector hook
- wire Shell to populate store and render Feed component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cf860b4a48321ac5996f82b59cf84