### PR TITLE
Ensure media preserves space with explicit image dimensions

### DIFF
--- a/vite-react-main/src/components/BrandBadge.tsx
+++ b/vite-react-main/src/components/BrandBadge.tsx
@@ -16,6 +16,10 @@ export default function BrandBadge({ onEnterUniverse }: { onEnterUniverse: () =>
           <img
             src="/supernova.png"
             alt="Supernova 2177 logo"
+            width={40}
+            height={40}
+            loading="lazy"
+            decoding="async"
             onError={(e)=>{ (e.currentTarget as HTMLImageElement).style.display='none'; }}
           />
         </button>

--- a/vite-react-main/src/components/Feed2D.tsx
+++ b/vite-react-main/src/components/Feed2D.tsx
@@ -49,7 +49,14 @@ function FeedCard({ post, onEnterWorld }: { post: any; onEnterWorld: (p: any, at
   return (
     <article className="nv-card" role="article" aria-label={post.title}>
       <div className="nv-media">
-        <img src={post.img} alt={post.title} loading="lazy" decoding="async" />
+        <img
+          src={post.img}
+          alt={post.title}
+          width={800}
+          height={1000}
+          loading="lazy"
+          decoding="async"
+        />
       </div>
 
       {/* Glass plaque (top, centered) */}

--- a/vite-react-main/src/components/PostCard.tsx
+++ b/vite-react-main/src/components/PostCard.tsx
@@ -38,7 +38,16 @@ export default function PostCard({ post, me, onOpenProfile, onEnterWorld }: Prop
         className="post-media"
         style={{ backgroundImage: imgUrl ? `url(${imgUrl})` : undefined }}
       >
-        {imgUrl && <img src={imgUrl} alt={imgAlt} loading="lazy" decoding="async" />}
+        {imgUrl && (
+          <img
+            src={imgUrl}
+            alt={imgAlt}
+            width={800}
+            height={1000}
+            loading="lazy"
+            decoding="async"
+          />
+        )}
       </div>
 
       {/* Frost BOTTOM — 5 equal cells: avatar + 4 evenly spaced icons */}

--- a/vite-react-main/src/components/Sidebar.tsx
+++ b/vite-react-main/src/components/Sidebar.tsx
@@ -58,6 +58,10 @@ export default function Sidebar() {
             <img
               src="/avatar.jpg"
               alt="me"
+              width={56}
+              height={56}
+              loading="lazy"
+              decoding="async"
               onError={(e) => { (e.currentTarget as HTMLImageElement).src = placeholderSvg; }}
             />
           </button>
@@ -78,6 +82,10 @@ export default function Sidebar() {
                 <img
                   src="/avatar.jpg"
                   alt="avatar"
+                  width={64}
+                  height={64}
+                  loading="lazy"
+                  decoding="async"
                   onError={(e) => { (e.currentTarget as HTMLImageElement).src = placeholderSvg; }}
                 />
               </button>


### PR DESCRIPTION
## Summary
- Keep post media within a fixed 4:5 aspect ratio container
- Specify explicit width and height on all image tags while retaining `loading="lazy"` and `decoding="async"`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cf86259b4832191a56130f5901ca6