### PR TITLE
Add animated brand orb and bus-driven sidebar toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/vite-react-main/src/components/BrandBadge.css
+++ b/vite-react-main/src/components/BrandBadge.css
@@ -1,0 +1,39 @@
+.brand-orb {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.8), rgba(255,255,255,0.1) 70%);
+  border: 2px solid rgba(255,255,255,0.3);
+  box-shadow: 0 0 8px rgba(11,102,255,0.6), inset 0 0 12px rgba(255,255,255,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.brand-orb svg {
+  width: 100%;
+  height: 100%;
+}
+
+.brand-orb.animating {
+  animation: brand-pop 0.4s ease;
+}
+
+@keyframes brand-pop {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 0 8px rgba(11,102,255,0.6), inset 0 0 12px rgba(255,255,255,0.5);
+  }
+  50% {
+    transform: scale(1.2);
+    box-shadow: 0 0 25px rgba(11,102,255,1), inset 0 0 16px rgba(255,255,255,0.7);
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 8px rgba(11,102,255,0.6), inset 0 0 12px rgba(255,255,255,0.5);
+  }
+}
+

--- a/vite-react-main/src/components/BrandBadge.tsx
+++ b/vite-react-main/src/components/BrandBadge.tsx
@@ -1,47 +1,50 @@
 import { useState } from "react";
 import bus from "../lib/bus";
+import "./BrandBadge.css";
 
-export default function BrandBadge({ onEnterUniverse }: { onEnterUniverse: () => void }) {
-  const [open, setOpen] = useState(false);
+export default function BrandBadge() {
+  const [animating, setAnimating] = useState(false);
+
+  const handleClick = () => {
+    if (animating) return;
+    setAnimating(true);
+    setTimeout(() => {
+      bus.emit("sidebar:toggle", undefined);
+      setAnimating(false);
+    }, 400);
+  };
 
   return (
-    <>
-      <div className="brand-wrap">
-        <button
-          className="brand-dot"
-          aria-label="Toggle brand menu"
-          onClick={() => setOpen(o => !o)}
-          onDoubleClick={() => bus.emit("sidebar:toggle", undefined)} /* bus.emit expects (event, payload) */
-        >
-          <img
-            src="/supernova.png"
-            alt="Supernova 2177 logo"
-            width={40}
-            height={40}
-            loading="lazy"
-            decoding="async"
-            onError={(e)=>{ (e.currentTarget as HTMLImageElement).style.display='none'; }}
-          />
-        </button>
-        <div className="brand-label">superNova2177</div>
-      </div>
-
-      {open && (
-        <div className="brand-menu">
-          <button onClick={() => bus.emit("chat:add", { role:"system", text:"Command palette (stub)" })}>
-            <svg className="ico" viewBox="0 0 24 24"><path d="M5 12h14M5 7h10M5 17h7" stroke="currentColor" strokeWidth="2" fill="none"/></svg>
-            <span>Command</span>
-          </button>
-          <button onClick={() => bus.emit("chat:add", { role:"assistant", text:"Remix current image (stub)" })}>
-            <svg className="ico" viewBox="0 0 24 24"><path d="M7 7h10v4H7zm0 6h6v4H7z" stroke="currentColor" strokeWidth="2" fill="none"/></svg>
-            <span>Remix</span>
-          </button>
-          <button onClick={onEnterUniverse}>
-            <svg className="ico" viewBox="0 0 24 24"><path d="M12 2v20M2 12h20" stroke="currentColor" strokeWidth="2" fill="none"/></svg>
-            <span>Enter Universe</span>
-          </button>
-        </div>
-      )}
-    </>
+    <div className="brand-wrap">
+      <button
+        className={`brand-orb ${animating ? "animating" : ""}`}
+        aria-label="Toggle sidebar"
+        onClick={handleClick}
+      >
+        <svg viewBox="0 0 100 100">
+          <defs>
+            <radialGradient id="orb-grad" cx="30%" cy="30%" r="70%">
+              <stop offset="0%" stopColor="#ffffff" stopOpacity="0.8" />
+              <stop offset="60%" stopColor="#0b66ff" stopOpacity="0.8" />
+              <stop offset="100%" stopColor="#001a44" stopOpacity="1" />
+            </radialGradient>
+          </defs>
+          <circle cx="50" cy="50" r="45" fill="url(#orb-grad)" />
+          <text
+            x="50"
+            y="58"
+            textAnchor="middle"
+            fontSize="32"
+            fontWeight="bold"
+            fill="#0b66ff"
+            fontFamily="sans-serif"
+          >
+            2177
+          </text>
+        </svg>
+      </button>
+      <div className="brand-label">superNova2177</div>
+    </div>
   );
 }
+

--- a/vite-react-main/src/components/Sidebar.tsx
+++ b/vite-react-main/src/components/Sidebar.tsx
@@ -33,6 +33,11 @@ export default function Sidebar() {
   useEffect(() => { bus.emit("search:update", { query }); }, [query]);
   useEffect(() => { bus.emit("backend:update", { useReal, backendUrl }); }, [useReal, backendUrl]);
 
+  useEffect(() => {
+    const unsub = bus.on("sidebar:toggle", () => setOpen(o => !o));
+    return () => unsub();
+  }, [setOpen]);
+
   const goto = (label: string) => bus.emit("nav:goto", { label });
 
   const placeholderSvg = `data:image/svg+xml;utf8,${encodeURIComponent(`


### PR DESCRIPTION
## Summary
- Replace image badge with animated SVG orb labeled "2177" that emits `sidebar:toggle` after a brief scale/glow animation
- Style the brand orb with a vibrant blue glass effect via new CSS
- Sidebar now listens for `sidebar:toggle` events and toggles its open state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: TypeScript errors in `Shell.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_689e6ad12e448321a0299aa09394493a